### PR TITLE
Add registration password requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # dontloseit
-A private flea market 
+A private flea market.
+
+## Registration Password
+
+The site requires a shared password for new accounts. Set the
+`RegistrationPassword` value in *appsettings.json* to control who can join.
+

--- a/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/Register.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,0 +1,38 @@
+@page
+@model FleaMarket.FrontEnd.Areas.Identity.Pages.Account.RegisterModel
+@{
+    ViewData["Title"] = "Register";
+}
+<h1>@ViewData["Title"]</h1>
+
+<form method="post">
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" />
+        <label asp-for="Input.Email"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Password" class="form-control" />
+        <label asp-for="Input.Password"></label>
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.ConfirmPassword" class="form-control" />
+        <label asp-for="Input.ConfirmPassword"></label>
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.SitePassword" class="form-control" />
+        <label asp-for="Input.SitePassword">Site Password</label>
+        <span asp-validation-for="Input.SitePassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>
+
+<div>
+    <a asp-page="./Login">Already have an account?</a>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace FleaMarket.FrontEnd.Areas.Identity.Pages.Account
+{
+    public class RegisterModel : PageModel
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly ILogger<RegisterModel> _logger;
+        private readonly IConfiguration _configuration;
+
+        public RegisterModel(
+            UserManager<IdentityUser> userManager,
+            SignInManager<IdentityUser> signInManager,
+            ILogger<RegisterModel> logger,
+            IConfiguration configuration)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new InputModel();
+
+        public string? ReturnUrl { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; } = string.Empty;
+
+            [Required]
+            [DataType(DataType.Password)]
+            public string Password { get; set; } = string.Empty;
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; } = string.Empty;
+
+            [Required]
+            [DataType(DataType.Password)]
+            [Display(Name = "Site Password")]
+            public string SitePassword { get; set; } = string.Empty;
+        }
+
+        public void OnGet(string? returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var expectedPassword = _configuration["RegistrationPassword"];
+            if (expectedPassword == null || Input.SitePassword != expectedPassword)
+            {
+                ModelState.AddModelError(string.Empty, "Invalid site password.");
+                return Page();
+            }
+
+            var user = new IdentityUser { UserName = Input.Email, Email = Input.Email };
+            var result = await _userManager.CreateAsync(user, Input.Password);
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("User created a new account with password.");
+                await _signInManager.SignInAsync(user, isPersistent: false);
+                return LocalRedirect(returnUrl ?? Url.Content("~/"));
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return Page();
+        }
+    }
+}
+

--- a/src/FleaMarket/FleaMarket.FrontEnd/appsettings.Development.json
+++ b/src/FleaMarket/FleaMarket.FrontEnd/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "RegistrationPassword": "secret"
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/appsettings.json
+++ b/src/FleaMarket/FleaMarket.FrontEnd/appsettings.json
@@ -8,5 +8,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RegistrationPassword": "secret"
 }


### PR DESCRIPTION
## Summary
- add a site password for new accounts in `appsettings.json`
- override ASP.NET Identity registration pages
- check the configured password during registration
- document the new setting

## Testing
- `dotnet build src/FleaMarket/FleaMarket.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc1956d5c8324b9f0d38030ead398