### PR TITLE
Add item listing page

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
@@ -1,0 +1,76 @@
+using FleaMarket.FrontEnd.Data;
+using FleaMarket.FrontEnd.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FleaMarket.FrontEnd.Controllers
+{
+    [Authorize]
+    public class ItemsController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly IWebHostEnvironment _env;
+
+        public ItemsController(ApplicationDbContext context, UserManager<IdentityUser> userManager, IWebHostEnvironment env)
+        {
+            _context = context;
+            _userManager = userManager;
+            _env = env;
+        }
+
+        [HttpGet]
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(ItemCreateViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var item = new Item
+            {
+                Name = model.Name,
+                Description = model.Description,
+                Price = model.IsFree ? null : model.Price,
+                OwnerId = _userManager.GetUserId(User)
+            };
+
+            _context.Items.Add(item);
+            await _context.SaveChangesAsync();
+
+            if (model.Images != null && model.Images.Count > 0)
+            {
+                var uploadDir = Path.Combine(_env.WebRootPath, "uploads");
+                Directory.CreateDirectory(uploadDir);
+
+                foreach (var image in model.Images)
+                {
+                    if (image.Length > 0)
+                    {
+                        var fileName = Guid.NewGuid().ToString() + Path.GetExtension(image.FileName);
+                        var filePath = Path.Combine(uploadDir, fileName);
+                        using var stream = new FileStream(filePath, FileMode.Create);
+                        await image.CopyToAsync(stream);
+
+                        item.Images.Add(new ItemImage
+                        {
+                            FileName = fileName
+                        });
+                    }
+                }
+
+                await _context.SaveChangesAsync();
+            }
+
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Data/ApplicationDbContext.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using FleaMarket.FrontEnd.Models;
 
 namespace FleaMarket.FrontEnd.Data
 {
@@ -9,5 +10,8 @@ namespace FleaMarket.FrontEnd.Data
             : base(options)
         {
         }
+
+        public DbSet<Item> Items { get; set; } = default!;
+        public DbSet<ItemImage> ItemImages { get; set; } = default!;
     }
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+
+namespace FleaMarket.FrontEnd.Models
+{
+    public class Item
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public decimal? Price { get; set; }
+
+        public string? OwnerId { get; set; }
+        public IdentityUser? Owner { get; set; }
+
+        public ICollection<ItemImage> Images { get; set; } = new List<ItemImage>();
+    }
+
+    public class ItemImage
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string FileName { get; set; } = string.Empty;
+
+        public int ItemId { get; set; }
+        public Item Item { get; set; } = null!;
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemCreateViewModel.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemCreateViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace FleaMarket.FrontEnd.Models
+{
+    public class ItemCreateViewModel
+    {
+        [Required]
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public bool IsFree { get; set; }
+
+        [Range(0, double.MaxValue)]
+        public decimal? Price { get; set; }
+
+        public List<IFormFile> Images { get; set; } = new List<IFormFile>();
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
@@ -1,0 +1,37 @@
+@model FleaMarket.FrontEnd.Models.ItemCreateViewModel
+@{
+    ViewData["Title"] = "List Item";
+}
+
+<h1>List Item</h1>
+
+<form asp-action="Create" method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+        <label asp-for="Name" class="form-label"></label>
+        <input asp-for="Name" class="form-control" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Description" class="form-label"></label>
+        <textarea asp-for="Description" class="form-control"></textarea>
+        <span asp-validation-for="Description" class="text-danger"></span>
+    </div>
+    <div class="mb-3 form-check">
+        <input asp-for="IsFree" class="form-check-input" />
+        <label asp-for="IsFree" class="form-check-label">Give away for free</label>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Price" class="form-label"></label>
+        <input asp-for="Price" class="form-control" />
+        <span asp-validation-for="Price" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label for="images" class="form-label">Photos</label>
+        <input type="file" name="Images" multiple accept="image/*" capture="environment" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Shared/_LoginPartial.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Shared/_LoginPartial.cshtml
@@ -9,6 +9,9 @@
         <a  class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @User.Identity?.Name!</a>
     </li>
     <li class="nav-item">
+        <a class="nav-link text-dark" asp-controller="Items" asp-action="Create">List Item</a>
+    </li>
+    <li class="nav-item">
         <form  class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
             <button  type="submit" class="nav-link btn btn-link text-dark">Logout</button>
         </form>


### PR DESCRIPTION
## Summary
- create model classes for items and images
- allow users to submit new items with price, description, and multiple photos
- secure the new page with authentication
- show "List Item" link when signed in

## Testing
- `dotnet build src/FleaMarket/FleaMarket.FrontEnd/FleaMarket.FrontEnd.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc498f7c48324bf9983273c0e78f5