### PR TITLE
Add all-listings page with reserve popup

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Controllers/HomeController.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Controllers/HomeController.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using FleaMarket.FrontEnd.Models;
+using FleaMarket.FrontEnd.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FleaMarket.FrontEnd.Controllers
@@ -7,15 +9,23 @@ namespace FleaMarket.FrontEnd.Controllers
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly ApplicationDbContext _context;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, ApplicationDbContext context)
         {
             _logger = logger;
+            _context = context;
         }
 
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
-            return View();
+            var items = await _context.Items
+                .Include(i => i.Owner)
+                .Where(i => !i.IsArchived)
+                .OrderBy(i => i.Price == null ? 0 : 1)
+                .ThenBy(i => i.Name)
+                .ToListAsync();
+            return View(items);
         }
 
         public IActionResult Privacy()

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
@@ -1,8 +1,33 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@model List<FleaMarket.FrontEnd.Models.Item>
+@{
+    ViewData["Title"] = "Listings";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
-</div>
+<h1>All Listings</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Price</th>
+            <th>Seller</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@item.Name</td>
+            <td>@item.Description</td>
+            <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
+            <td>@item.Owner?.Email</td>
+            <td>
+                <button type="button" class="btn btn-sm btn-primary reserve-button" data-item-name="@item.Name" data-seller-email="@item.Owner?.Email">Reserve</button>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>
+

--- a/src/FleaMarket/FleaMarket.FrontEnd/wwwroot/js/site.js
+++ b/src/FleaMarket/FleaMarket.FrontEnd/wwwroot/js/site.js
@@ -2,3 +2,13 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+// Handle reservation button clicks on the listings page.
+$(document).on('click', '.reserve-button', function () {
+    const itemName = $(this).data('item-name');
+    const sellerEmail = $(this).data('seller-email');
+    const confirmed = confirm('Reserve "' + itemName + '"?\n\nYou will need to contact the seller directly to complete the purchase.');
+    if (confirmed) {
+        alert('Reservation noted! Please email ' + sellerEmail + ' to arrange pickup or payment.');
+    }
+});


### PR DESCRIPTION
## Summary
- display every non-archived item on the home page
- add Reserve buttons that ask for confirmation
- encourage contacting the seller directly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bca2589d88324b0852d72c36a2dfd