### PR TITLE
Improve listings and reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # dontloseit
 A private flea market.
 
+## New features
+
+* Listings can now be reserved and marked as sold.
+* Visitors can search across all active listings.
+* Sellers can manage item photos when editing.
+
 ## Registration Password
 
 The site requires a shared password for new accounts. Set the

--- a/src/FleaMarket/FleaMarket.FrontEnd/Data/ApplicationDbContext.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Data/ApplicationDbContext.cs
@@ -13,5 +13,6 @@ namespace FleaMarket.FrontEnd.Data
 
         public DbSet<Item> Items { get; set; } = default!;
         public DbSet<ItemImage> ItemImages { get; set; } = default!;
+        public DbSet<Reservation> Reservations { get; set; } = default!;
     }
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
@@ -18,6 +18,10 @@ namespace FleaMarket.FrontEnd.Models
 
         public bool IsArchived { get; set; }
 
+        public bool IsReserved { get; set; }
+
+        public bool IsSold { get; set; }
+
         public string? OwnerId { get; set; }
         public IdentityUser? Owner { get; set; }
 

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemEditViewModel.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemEditViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace FleaMarket.FrontEnd.Models
+{
+    public class ItemEditViewModel : ItemCreateViewModel
+    {
+        public List<ItemImage> ExistingImages { get; set; } = new();
+        public List<int> RemoveImageIds { get; set; } = new();
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/Reservation.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/Reservation.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+
+namespace FleaMarket.FrontEnd.Models
+{
+    public class Reservation
+    {
+        public int Id { get; set; }
+
+        public int ItemId { get; set; }
+        public Item Item { get; set; } = null!;
+
+        public string BuyerId { get; set; } = string.Empty;
+        public IdentityUser Buyer { get; set; } = null!;
+
+        public DateTime Created { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
@@ -1,30 +1,60 @@
-@model List<FleaMarket.FrontEnd.Models.Item>
+@model FleaMarket.FrontEnd.Models.ItemsIndexViewModel
 @{
     ViewData["Title"] = "Listings";
 }
 
 <h1>All Listings</h1>
 
+@if (TempData["Message"] != null)
+{
+    <div class="alert alert-success">@TempData["Message"]</div>
+}
+
+<form method="get" class="row g-3 mb-3">
+    <div class="col-auto">
+        <input type="text" name="search" value="@Model.Search" class="form-control" placeholder="Search" />
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Filter</button>
+    </div>
+</form>
+
 <table class="table">
     <thead>
         <tr>
+            <th></th>
             <th>Name</th>
             <th>Description</th>
             <th>Price</th>
             <th>Seller</th>
+            <th>Status</th>
             <th></th>
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model)
+@foreach (var item in Model.Items)
 {
         <tr>
+            <td>
+                @if (item.Images.Any())
+                {
+                    <img src="/uploads/@item.Images.First().FileName" alt="@item.Name" style="max-width:80px;" />
+                }
+            </td>
             <td>@item.Name</td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
             <td>@item.Owner?.Email</td>
             <td>
-                <button type="button" class="btn btn-sm btn-primary reserve-button" data-item-name="@item.Name" data-seller-email="@item.Owner?.Email">Reserve</button>
+                @(item.IsReserved ? "Reserved" : item.IsSold ? "Sold" : "Available")
+            </td>
+            <td>
+                @if (!item.IsReserved && !item.IsSold)
+                {
+                    <form asp-action="Reserve" asp-route-id="@item.Id" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-sm btn-primary">Reserve</button>
+                    </form>
+                }
             </td>
         </tr>
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
@@ -27,7 +27,8 @@
     </div>
     <div class="mb-3">
         <label for="images" class="form-label">Photos</label>
-        <input type="file" name="Images" multiple accept="image/*" capture="environment" class="form-control" />
+        <input type="file" id="images" name="Images" multiple accept="image/*" capture="environment" class="form-control" />
+        <div id="imagePreview" class="row mt-2"></div>
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Edit.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Edit.cshtml
@@ -1,4 +1,4 @@
-@model FleaMarket.FrontEnd.Models.ItemCreateViewModel
+@model FleaMarket.FrontEnd.Models.ItemEditViewModel
 @{
     ViewData["Title"] = "Edit Item";
     var itemId = (int)ViewData["ItemId"];
@@ -26,6 +26,29 @@
         <input asp-for="Price" class="form-control" />
         <span asp-validation-for="Price" class="text-danger"></span>
     </div>
+    <div class="mb-3">
+        <label for="images" class="form-label">Add Photos</label>
+        <input type="file" name="Images" multiple accept="image/*" class="form-control" />
+    </div>
+    @if (Model.ExistingImages.Any())
+    {
+        <div class="mb-3">
+            <label class="form-label">Existing Photos</label>
+            <div class="row">
+            @for (int i = 0; i < Model.ExistingImages.Count; i++)
+            {
+                var image = Model.ExistingImages[i];
+                <div class="col-6 col-md-3 text-center mb-2">
+                    <img src="/uploads/@image.FileName" alt="Photo" class="img-fluid mb-1" />
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" name="RemoveImageIds" value="@image.Id" id="remove_@image.Id" />
+                        <label class="form-check-label" for="remove_@image.Id">Remove</label>
+                    </div>
+                </div>
+            }
+            </div>
+        </div>
+    }
     <button type="submit" class="btn btn-primary">Save</button>
 </form>
 

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
@@ -21,9 +21,11 @@
 <table class="table">
     <thead>
         <tr>
+            <th></th>
             <th>Name</th>
             <th>Description</th>
             <th>Price</th>
+            <th>Status</th>
             <th></th>
         </tr>
     </thead>
@@ -31,12 +33,31 @@
 @foreach (var item in Model.Items)
 {
         <tr>
+            <td>
+                @if (item.Images.Any())
+                {
+                    <img src="/uploads/@item.Images.First().FileName" alt="@item.Name" style="max-width:80px;" />
+                }
+            </td>
             <td>@item.Name</td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
+            <td>@(item.IsSold ? "Sold" : item.IsReserved ? "Reserved" : "Available")</td>
             <td>
                 <div class="btn-group" role="group">
                     <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary">Edit</a>
+                    @if (!item.IsSold)
+                    {
+                        <form asp-action="MarkSold" asp-route-id="@item.Id" method="post" class="d-inline">
+                            <button type="submit" class="btn btn-sm btn-success">Mark Sold</button>
+                        </form>
+                    }
+                    else
+                    {
+                        <form asp-action="MarkAvailable" asp-route-id="@item.Id" method="post" class="d-inline">
+                            <button type="submit" class="btn btn-sm btn-success">Mark Available</button>
+                        </form>
+                    }
                     <form asp-action="Archive" asp-route-id="@item.Id" method="post" class="d-inline">
                         <button type="submit" class="btn btn-sm btn-warning">Archive</button>
                     </form>

--- a/src/FleaMarket/FleaMarket.FrontEnd/wwwroot/js/site.js
+++ b/src/FleaMarket/FleaMarket.FrontEnd/wwwroot/js/site.js
@@ -3,12 +3,20 @@
 
 // Write your JavaScript code.
 
-// Handle reservation button clicks on the listings page.
-$(document).on('click', '.reserve-button', function () {
-    const itemName = $(this).data('item-name');
-    const sellerEmail = $(this).data('seller-email');
-    const confirmed = confirm('Reserve "' + itemName + '"?\n\nYou will need to contact the seller directly to complete the purchase.');
-    if (confirmed) {
-        alert('Reservation noted! Please email ' + sellerEmail + ' to arrange pickup or payment.');
-    }
+
+// Preview selected images when listing an item.
+$(document).on('change', '#images', function () {
+    const preview = $('#imagePreview');
+    preview.empty();
+    const files = this.files;
+    if (!files) return;
+    Array.from(files).forEach(file => {
+        const reader = new FileReader();
+        reader.onload = e => {
+            const col = $('<div class="col-6 col-md-3 mb-2"></div>');
+            $('<img class="img-fluid" />').attr('src', e.target.result).appendTo(col);
+            col.appendTo(preview);
+        };
+        reader.readAsDataURL(file);
+    });
 });


### PR DESCRIPTION
## Summary
- track reservations and allow items to be reserved/sold
- add item photo editing and preview scripts
- enable searching across all listings
- display item images and status

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bcd4ef648832490140bc63fbf19a7