### PR TITLE
Add item details page

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
@@ -243,5 +243,22 @@ namespace FleaMarket.FrontEnd.Controllers
 
             return RedirectToAction(nameof(Index));
         }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> Details(int id)
+        {
+            var item = await _context.Items
+                .Include(i => i.Images)
+                .Include(i => i.Owner)
+                .FirstOrDefaultAsync(i => i.Id == id);
+
+            if (item == null)
+            {
+                return NotFound();
+            }
+
+            return View(item);
+        }
     }
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
@@ -42,7 +42,11 @@
                     <img src="/uploads/@item.Images.First().FileName" alt="@item.Name" style="max-width:80px;" />
                 }
             </td>
-            <td>@item.Name</td>
+            <td>
+                <a asp-controller="Items" asp-action="Details" asp-route-id="@item.Id">
+                    @item.Name
+                </a>
+            </td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
             <td>@item.Owner?.Email</td>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Details.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Details.cshtml
@@ -1,0 +1,47 @@
+@model FleaMarket.FrontEnd.Models.Item
+@{
+    ViewData["Title"] = "Item Details";
+}
+
+<h1>@Model.Name</h1>
+<div class="row mb-4">
+    <div class="col-md-6">
+        @if (Model.Images.Any())
+        {
+            <div id="itemCarousel" class="carousel slide mb-3">
+                <div class="carousel-inner">
+                @for (int i = 0; i < Model.Images.Count; i++)
+                {
+                    var img = Model.Images.ElementAt(i);
+                    <div class="carousel-item @(i == 0 ? "active" : "")">
+                        <img src="/uploads/@img.FileName" class="d-block w-100" alt="@Model.Name" />
+                    </div>
+                }
+                </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#itemCarousel" data-bs-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#itemCarousel" data-bs-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Next</span>
+                </button>
+            </div>
+        }
+    </div>
+    <div class="col-md-6">
+        <p>@Model.Description</p>
+        <p><strong>Price:</strong> @(Model.Price == null ? "Free" : Model.Price?.ToString("C"))</p>
+        <p><strong>Seller:</strong> @Model.Owner?.Email</p>
+        @if (!Model.IsReserved && !Model.IsSold)
+        {
+            <form asp-controller="Home" asp-action="Reserve" asp-route-id="@Model.Id" method="post">
+                <button type="submit" class="btn btn-primary">Reserve</button>
+            </form>
+        }
+        else
+        {
+            <span class="badge bg-secondary">@(Model.IsSold ? "Sold" : "Reserved")</span>
+        }
+    </div>
+</div>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
@@ -40,7 +40,11 @@
                     <img src="/uploads/@item.Images.First().FileName" alt="@item.Name" style="max-width:80px;" />
                 }
             </td>
-            <td>@item.Name</td>
+            <td>
+                <a asp-controller="Items" asp-action="Details" asp-route-id="@item.Id">
+                    @item.Name
+                </a>
+            </td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
             <td>@(item.IsSold ? "Sold" : item.IsReserved ? "Reserved" : "Available")</td>


### PR DESCRIPTION
## Summary
- add `Details` action in ItemsController for viewing item info
- create Details view with carousel and reserve button
- link item names on Home and Items index pages to detail view

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687404e9866c8324bced852533d14d1d