### PR TITLE
Add deadline support for items

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Controllers/ItemsController.cs
@@ -44,6 +44,7 @@ namespace FleaMarket.FrontEnd.Controllers
                 Name = model.Name,
                 Description = model.Description,
                 Price = model.IsFree ? null : model.Price,
+                Deadline = model.Deadline,
                 OwnerId = _userManager.GetUserId(User)
             };
 
@@ -128,6 +129,7 @@ namespace FleaMarket.FrontEnd.Controllers
                 Description = item.Description,
                 IsFree = item.Price == null,
                 Price = item.Price,
+                Deadline = item.Deadline,
                 ExistingImages = item.Images.ToList()
             };
 
@@ -157,6 +159,7 @@ namespace FleaMarket.FrontEnd.Controllers
             item.Name = model.Name;
             item.Description = model.Description;
             item.Price = model.IsFree ? null : model.Price;
+            item.Deadline = model.Deadline;
 
             if (model.RemoveImageIds?.Count > 0)
             {

--- a/src/FleaMarket/FleaMarket.FrontEnd/Data/Migrations/20250625130000_deadline.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Data/Migrations/20250625130000_deadline.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FleaMarket.FrontEnd.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class deadline : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Deadline",
+                table: "Items",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Deadline",
+                table: "Items");
+        }
+    }
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -53,6 +53,9 @@ namespace FleaMarket.FrontEnd.Data.Migrations
                     b.Property<decimal?>("Price")
                         .HasColumnType("decimal(18,2)");
 
+                    b.Property<DateTime?>("Deadline")
+                        .HasColumnType("datetime2");
+
                     b.HasKey("Id");
 
                     b.HasIndex("OwnerId");

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/Item.cs
@@ -15,6 +15,8 @@ namespace FleaMarket.FrontEnd.Models
 
         public decimal? Price { get; set; }
 
+        public DateTime? Deadline { get; set; }
+
         public bool IsArchived { get; set; }
 
         public bool IsReserved { get; set; }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemCreateViewModel.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Models/ItemCreateViewModel.cs
@@ -16,6 +16,9 @@ namespace FleaMarket.FrontEnd.Models
         [Range(0, double.MaxValue)]
         public decimal? Price { get; set; }
 
+        [DataType(DataType.DateTime)]
+        public DateTime? Deadline { get; set; }
+
         public List<IFormFile> Images { get; set; } = new List<IFormFile>();
     }
 }

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Home/Index.cshtml
@@ -27,6 +27,7 @@
             <th>Name</th>
             <th>Description</th>
             <th>Price</th>
+            <th>Deadline</th>
             <th>Seller</th>
             <th>Status</th>
             <th></th>
@@ -49,6 +50,7 @@
             </td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
+            <td>@item.Deadline?.ToString("g")</td>
             <td>
                 @if (item.Owner?.ProfileImageFileName != null)
                 {

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Create.cshtml
@@ -27,6 +27,11 @@
         <span asp-validation-for="Price" class="text-danger"></span>
     </div>
     <div class="mb-3">
+        <label asp-for="Deadline" class="form-label"></label>
+        <input asp-for="Deadline" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm}" class="form-control" />
+        <span asp-validation-for="Deadline" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
         <label for="images" class="form-label">Photos</label>
         <input type="file" id="images" name="Images" multiple accept="image/*" capture="environment" class="form-control" />
         <div id="imagePreview" class="row mt-2"></div>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Details.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Details.cshtml
@@ -32,6 +32,7 @@
     <div class="col-md-6">
         <p>@Model.Description</p>
         <p><strong>Price:</strong> @(Model.Price == null ? "Free" : Model.Price?.ToString("C"))</p>
+        <p><strong>Deadline:</strong> @Model.Deadline?.ToString("g")</p>
         <p>
             <strong>Seller:</strong>
             @if (Model.Owner?.ProfileImageFileName != null)

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Edit.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Edit.cshtml
@@ -28,6 +28,11 @@
         <span asp-validation-for="Price" class="text-danger"></span>
     </div>
     <div class="mb-3">
+        <label asp-for="Deadline" class="form-label"></label>
+        <input asp-for="Deadline" type="datetime-local" asp-format="{0:yyyy-MM-ddTHH:mm}" class="form-control" />
+        <span asp-validation-for="Deadline" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
         <label for="images" class="form-label">Add Photos</label>
         <input type="file" name="Images" multiple accept="image/*" class="form-control" />
     </div>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Views/Items/Index.cshtml
@@ -26,6 +26,7 @@
             <th>Name</th>
             <th>Description</th>
             <th>Price</th>
+            <th>Deadline</th>
             <th>Status</th>
             <th></th>
         </tr>
@@ -47,6 +48,7 @@
             </td>
             <td>@item.Description</td>
             <td>@(item.Price == null ? "Free" : item.Price?.ToString("C"))</td>
+            <td>@item.Deadline?.ToString("g")</td>
             <td>@(item.IsSold ? "Sold" : item.IsReserved ? "Reserved" : "Available")</td>
             <td>
                 <div class="btn-group" role="group">


### PR DESCRIPTION
## Summary
- add `Deadline` field to `Item`
- update create/edit view models and controllers
- show deadline in item forms, listings and details
- include EF Core migration for the new column

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687636af915c8324987e1ccd6956c658