### PR TITLE
Add Microsoft/Google/Facebook auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ A private flea market.
 The site requires a shared password for new accounts. Set the
 `RegistrationPassword` value in *appsettings.json* to control who can join.
 
+## External Authentication
+
+The site supports Microsoft, Google, and Facebook logins. Configure the
+credentials using environment variables:
+
+```
+Authentication__Microsoft__ClientId=<id>
+Authentication__Microsoft__ClientSecret=<secret>
+Authentication__Google__ClientId=<id>
+Authentication__Google__ClientSecret=<secret>
+Authentication__Facebook__AppId=<id>
+Authentication__Facebook__AppSecret=<secret>
+```
+
+These values can also be stored in user secrets during development.
+
 
 ## Deployment
 

--- a/src/FleaMarket/FleaMarket.FrontEnd/FleaMarket.FrontEnd.csproj
+++ b/src/FleaMarket/FleaMarket.FrontEnd/FleaMarket.FrontEnd.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.15" />
   </ItemGroup>
 
 </Project>

--- a/src/FleaMarket/FleaMarket.FrontEnd/Program.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Program.cs
@@ -19,6 +19,22 @@ namespace FleaMarket.FrontEnd
 
             builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddEntityFrameworkStores<ApplicationDbContext>();
+            builder.Services.AddAuthentication()
+                .AddMicrosoftAccount(o =>
+                {
+                    o.ClientId = builder.Configuration["Authentication:Microsoft:ClientId"]!;
+                    o.ClientSecret = builder.Configuration["Authentication:Microsoft:ClientSecret"]!;
+                })
+                .AddGoogle(o =>
+                {
+                    o.ClientId = builder.Configuration["Authentication:Google:ClientId"]!;
+                    o.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"]!;
+                })
+                .AddFacebook(o =>
+                {
+                    o.AppId = builder.Configuration["Authentication:Facebook:AppId"]!;
+                    o.AppSecret = builder.Configuration["Authentication:Facebook:AppSecret"]!;
+                });
             builder.Services.AddControllersWithViews();
 
             builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp"));
@@ -45,6 +61,7 @@ namespace FleaMarket.FrontEnd
 
             app.UseRouting();
 
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.MapControllerRoute(

--- a/src/FleaMarket/FleaMarket.FrontEnd/appsettings.json
+++ b/src/FleaMarket/FleaMarket.FrontEnd/appsettings.json
@@ -13,5 +13,19 @@
     "User": "your-smtp-username",
     "Password": "your-smtp-password",
     "From": "noreply@example.com"
+  },
+  "Authentication": {
+    "Microsoft": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Facebook": {
+      "AppId": "",
+      "AppSecret": ""
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Microsoft/Google/Facebook packages
- configure external login providers in Program.cs
- expose placeholders in `appsettings.json`
- document environment variables in README

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a28ceadc083249e941109c5b44d8e