### PR TITLE
Add ExternalLogin page with site password

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/ExternalLogin.cshtml
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/ExternalLogin.cshtml
@@ -1,0 +1,27 @@
+@page
+@model FleaMarket.FrontEnd.Areas.Identity.Pages.Account.ExternalLoginModel
+@{
+    ViewData["Title"] = "External Login";
+}
+
+<h1>Register with @Model.ProviderDisplayName</h1>
+
+<form method="post" asp-page-handler="Confirmation">
+    <div asp-validation-summary="All" class="text-danger"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" placeholder="Email" />
+        <label asp-for="Input.Email"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.SitePassword" class="form-control" placeholder="Site password" />
+        <label asp-for="Input.SitePassword">Site Password</label>
+        <span asp-validation-for="Input.SitePassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create Account</button>
+    <input type="hidden" asp-for="ReturnUrl" />
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using FleaMarket.FrontEnd.Models;
+
+namespace FleaMarket.FrontEnd.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class ExternalLoginModel : PageModel
+    {
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IUserStore<ApplicationUser> _userStore;
+        private readonly ILogger<ExternalLoginModel> _logger;
+        private readonly IConfiguration _configuration;
+
+        public ExternalLoginModel(
+            SignInManager<ApplicationUser> signInManager,
+            UserManager<ApplicationUser> userManager,
+            IUserStore<ApplicationUser> userStore,
+            ILogger<ExternalLoginModel> logger,
+            IConfiguration configuration)
+        {
+            _signInManager = signInManager;
+            _userManager = userManager;
+            _userStore = userStore;
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new InputModel();
+
+        public string? ProviderDisplayName { get; set; }
+
+        public string? ReturnUrl { get; set; }
+
+        public string? ErrorMessage { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; } = string.Empty;
+
+            [Required]
+            [DataType(DataType.Password)]
+            [Display(Name = "Site Password")]
+            public string SitePassword { get; set; } = string.Empty;
+        }
+
+        public IActionResult OnGet() => RedirectToPage("./Login");
+
+        public async Task<IActionResult> OnGetCallbackAsync(string? returnUrl = null, string? remoteError = null)
+        {
+            returnUrl ??= Url.Content("~/");
+            ReturnUrl = returnUrl;
+            if (remoteError != null)
+            {
+                ErrorMessage = $"Error from external provider: {remoteError}";
+                return RedirectToPage("./Login", new { ReturnUrl = returnUrl });
+            }
+
+            var info = await _signInManager.GetExternalLoginInfoAsync();
+            if (info == null)
+            {
+                ErrorMessage = "Error loading external login information.";
+                return RedirectToPage("./Login", new { ReturnUrl = returnUrl });
+            }
+
+            var signInResult = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor : true);
+            if (signInResult.Succeeded)
+            {
+                await _signInManager.UpdateExternalAuthenticationTokensAsync(info);
+                _logger.LogInformation("User logged in with {Name} provider.", info.LoginProvider);
+                return LocalRedirect(returnUrl);
+            }
+            if (signInResult.IsLockedOut)
+            {
+                return RedirectToPage("./Lockout");
+            }
+            else
+            {
+                ProviderDisplayName = info.ProviderDisplayName;
+                if (info.Principal.HasClaim(c => c.Type == ClaimTypes.Email))
+                {
+                    Input.Email = info.Principal.FindFirstValue(ClaimTypes.Email)!;
+                }
+                return Page();
+            }
+        }
+
+        public async Task<IActionResult> OnPostConfirmationAsync(string? returnUrl = null)
+        {
+            returnUrl ??= Url.Content("~/");
+            ReturnUrl = returnUrl;
+            var info = await _signInManager.GetExternalLoginInfoAsync();
+            if (info == null)
+            {
+                ErrorMessage = "Error loading external login information during confirmation.";
+                return RedirectToPage("./Login", new { ReturnUrl = returnUrl });
+            }
+
+            if (!ModelState.IsValid)
+            {
+                ProviderDisplayName = info.ProviderDisplayName;
+                return Page();
+            }
+
+            var expectedPassword = _configuration["RegistrationPassword"];
+            if (expectedPassword == null || Input.SitePassword != expectedPassword)
+            {
+                ModelState.AddModelError(string.Empty, "Invalid site password.");
+                ProviderDisplayName = info.ProviderDisplayName;
+                return Page();
+            }
+
+            var user = Activator.CreateInstance<ApplicationUser>();
+            await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+            if (_userManager.SupportsUserEmail)
+            {
+                await _userManager.SetEmailAsync(user, Input.Email);
+            }
+
+            var result = await _userManager.CreateAsync(user);
+            if (result.Succeeded)
+            {
+                result = await _userManager.AddLoginAsync(user, info);
+                if (result.Succeeded)
+                {
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    await _signInManager.UpdateExternalAuthenticationTokensAsync(info);
+                    _logger.LogInformation("User created an account using {Name} provider.", info.LoginProvider);
+                    return LocalRedirect(returnUrl);
+                }
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            ProviderDisplayName = info.ProviderDisplayName;
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add custom ExternalLogin Razor page
- require `SitePassword` before creating user via external auth

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5c03282c8324926a8f48b055fc48