### PR TITLE
Handle profile images on external login

### DIFF
--- a/src/FleaMarket/FleaMarket.FrontEnd/Program.cs
+++ b/src/FleaMarket/FleaMarket.FrontEnd/Program.cs
@@ -3,6 +3,7 @@ using FleaMarket.FrontEnd.Services;
 using Microsoft.AspNetCore.Identity;
 using FleaMarket.FrontEnd.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication;
 
 namespace FleaMarket.FrontEnd
 {
@@ -29,11 +30,14 @@ namespace FleaMarket.FrontEnd
                 {
                     o.ClientId = builder.Configuration["Authentication:Google:ClientId"]!;
                     o.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"]!;
+                    o.ClaimActions.MapJsonKey("picture", "picture", "url");
                 })
                 .AddFacebook(o =>
                 {
                     o.AppId = builder.Configuration["Authentication:Facebook:AppId"]!;
                     o.AppSecret = builder.Configuration["Authentication:Facebook:AppSecret"]!;
+                    o.Fields.Add("picture");
+                    o.ClaimActions.MapJsonSubKey("urn:facebook:picture", "picture", "data", "url");
                 });
             builder.Services.AddControllersWithViews();
 


### PR DESCRIPTION
## Summary
- add avatar processing to ExternalLogin page
- update auth provider options to map avatar picture claim
- fix compile errors by adding Authentication namespace and scoping File IO

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a626362b08324873760ebadd9f4f3